### PR TITLE
Fix Mumble URL parsing

### DIFF
--- a/src/androidTest/java/com/morlunk/jumble/test/URLParserTest.java
+++ b/src/androidTest/java/com/morlunk/jumble/test/URLParserTest.java
@@ -78,6 +78,18 @@ public class URLParserTest extends TestCase {
         }
     }
 
+    public void testURLWithPassword() {
+        String url = "mumble://:mypassword@server.com/";
+        try {
+            Server server = MumbleURLParser.parseURL(url);
+            assertEquals(server.getHost(), "server.com");
+            assertEquals(server.getPassword(), "mypassword");
+            assertEquals(server.getPort(), Constants.DEFAULT_PORT);
+        } catch (MalformedURLException e) {
+            fail("Failed to parse URL.");
+        }
+    }
+
     public void testInvalidScheme() {
         String url = "grumble://server.com/";
         try {

--- a/src/main/java/com/morlunk/jumble/util/MumbleURLParser.java
+++ b/src/main/java/com/morlunk/jumble/util/MumbleURLParser.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
  */
 public class MumbleURLParser {
 
-    private static final Pattern URL_PATTERN = Pattern.compile("mumble://((.+?)(:(.+?))?@)?(.+?)(:([0-9]+?))?/");
+    private static final Pattern URL_PATTERN = Pattern.compile("mumble://(([^:]+)?(:(.+?))?@)?(.+?)(:([0-9]+?))?/");
 
     /**
      * Parses the passed Mumble URL into a Server object.


### PR DESCRIPTION
URLs including password but no username were parsed incorrectly. The
Mumble Wiki's specification is somewhat confusing for this case. The
General URL specification implies an username is needed to use a
password but later on page it is clear that password can be used
without an accompanying username.

The desktop client also supports these URLs.